### PR TITLE
Add session processor module and tests

### DIFF
--- a/src/session_processor.py
+++ b/src/session_processor.py
@@ -1,0 +1,39 @@
+import json
+from dataclasses import dataclass, asdict
+from typing import List, Dict, Any
+
+@dataclass
+class Message:
+    type: str
+    content: str
+
+
+def load_conversation(path: str) -> Any:
+    """Load a JSON conversation log from ``path``."""
+    with open(path, "r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def parse_messages(conversation: Any) -> List[Message]:
+    """Parse a conversation object into ``Message`` instances."""
+    # conversation may be {"messages": [...]} or just a list of messages
+    if isinstance(conversation, dict):
+        messages = conversation.get("messages", [])
+    else:
+        messages = conversation
+
+    parsed: List[Message] = []
+    for msg in messages:
+        role = msg.get("role")
+        content = msg.get("content")
+        if role not in {"system", "user", "assistant"}:
+            raise ValueError(f"Unknown role: {role}")
+        parsed.append(Message(type=role, content=content))
+    return parsed
+
+
+def normalize_conversation(path: str) -> Dict[str, List[Dict[str, str]]]:
+    """Load, parse and return a normalized dictionary for the conversation."""
+    conv = load_conversation(path)
+    messages = parse_messages(conv)
+    return {"conversation": [asdict(m) for m in messages]}

--- a/tests/test_session_processor.py
+++ b/tests/test_session_processor.py
@@ -1,0 +1,39 @@
+import os, sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+import json
+import tempfile
+
+from src.session_processor import load_conversation, parse_messages, normalize_conversation, Message
+
+sample_data = {
+    "messages": [
+        {"role": "system", "content": "You are a helpful assistant."},
+        {"role": "user", "content": "Hello"},
+        {"role": "assistant", "content": "Hi there!"},
+    ]
+}
+
+
+def test_load_and_parse():
+    with tempfile.NamedTemporaryFile("w", delete=False) as tmp:
+        json.dump(sample_data, tmp)
+        tmp_path = tmp.name
+
+    conv = load_conversation(tmp_path)
+    os.unlink(tmp_path)
+    assert conv == sample_data
+
+    msgs = parse_messages(conv)
+    assert [m.type for m in msgs] == ["system", "user", "assistant"]
+    assert msgs[1].content == "Hello"
+
+
+def test_normalize_conversation(tmp_path_factory):
+    path = tmp_path_factory.mktemp("data") / "conv.json"
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump(sample_data, f)
+
+    normalized = normalize_conversation(str(path))
+    assert list(normalized.keys()) == ["conversation"]
+    assert normalized["conversation"][0]["type"] == "system"
+    assert normalized["conversation"][2]["content"] == "Hi there!"


### PR DESCRIPTION
## Summary
- add `session_processor` module for loading and normalizing conversation logs
- create unit tests for conversation processing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684790bc509083319acab60445950bab

## Summary by Sourcery

Introduce a session_processor module to load, parse, and normalize conversation logs and add unit tests to validate its functionality.

New Features:
- Add session_processor module with load_conversation, parse_messages, and normalize_conversation functions for handling conversation logs

Tests:
- Add unit tests to verify loading and parsing of conversation data and to validate normalized conversation output