### PR TITLE
Add prompt packaging modules and config generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,10 @@
 # ai-musicology-gpt
+
+This project contains utilities for packaging prompt-related data structures
+and generating configuration files for custom GPT workflows.
+
+To generate configuration files from a session JSON file, run:
+
+```bash
+python generate_gpt_config.py <session_data.json> [output_dir]
+```

--- a/generate_gpt_config.py
+++ b/generate_gpt_config.py
@@ -1,0 +1,96 @@
+import json
+import os
+import sys
+from dataclasses import asdict
+from prompt_modules import (
+    PromptTemplate,
+    AgentPersona,
+    WorkflowMap,
+    CorrectionLoop,
+    Guardrail,
+)
+
+
+def load_session_data(path: str) -> dict:
+    with open(path, 'r') as f:
+        return json.load(f)
+
+
+def write_json(obj, path: str):
+    with open(path, 'w') as f:
+        json.dump(obj, f, indent=2)
+
+
+def generate_files(session_path: str, output_dir: str = '.'):
+    data = load_session_data(session_path)
+
+    pt = PromptTemplate(**data.get('prompt_template', {}))
+    ap = AgentPersona(**data.get('agent_persona', {}))
+    wm = WorkflowMap(**data.get('workflow_map', {}))
+    cl = CorrectionLoop(**data.get('correction_loop', {}))
+    gr = Guardrail(**data.get('guardrail', {}))
+
+    os.makedirs(output_dir, exist_ok=True)
+
+    write_json(asdict(pt), os.path.join(output_dir, 'prompt_template.json'))
+    write_json(asdict(ap), os.path.join(output_dir, 'agent_persona.json'))
+    write_json(asdict(wm), os.path.join(output_dir, 'workflow_map.json'))
+    write_json(asdict(cl), os.path.join(output_dir, 'correction_loop.json'))
+    write_json(asdict(gr), os.path.join(output_dir, 'guardrail.json'))
+
+    custom = {
+        'prompt_template': asdict(pt),
+        'agent_persona': asdict(ap),
+        'workflow_map': asdict(wm),
+        'correction_loop': asdict(cl),
+        'guardrail': asdict(gr),
+    }
+    write_json(custom, os.path.join(output_dir, 'custom_gpt_config.json'))
+
+    md_lines = [
+        '# Workspace Project',
+        '',
+        '## Prompt Template',
+        f"Name: {pt.name}",
+        '',
+        '```',
+        pt.template,
+        '```',
+        '',
+        '## Agent Persona',
+        f"Name: {ap.name}",
+        '',
+        ap.description,
+        '',
+        '## Workflow Map',
+    ]
+    md_lines.extend(f"- {step}" for step in wm.steps)
+    md_lines.extend([
+        '',
+        '## Correction Loop',
+        f"Max Iterations: {cl.max_iterations}",
+        f"Criteria: {cl.criteria}",
+        '',
+        '## Guardrail',
+    ])
+    md_lines.extend(f"- {rule}" for rule in gr.rules)
+    md_lines.append('')
+
+    with open(os.path.join(output_dir, 'workspace_project.md'), 'w') as f:
+        f.write('\n'.join(md_lines))
+
+
+def main(args=None):
+    if args is None:
+        args = sys.argv[1:]
+    if not args:
+        print('Usage: generate_gpt_config.py <session_data.json> [output_dir]')
+        return 1
+    session_path = args[0]
+    output_dir = args[1] if len(args) > 1 else '.'
+    generate_files(session_path, output_dir)
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/prompt_modules/__init__.py
+++ b/prompt_modules/__init__.py
@@ -1,0 +1,13 @@
+from .prompt_template import PromptTemplate
+from .agent_persona import AgentPersona
+from .workflow_map import WorkflowMap
+from .correction_loop import CorrectionLoop
+from .guardrail import Guardrail
+
+__all__ = [
+    "PromptTemplate",
+    "AgentPersona",
+    "WorkflowMap",
+    "CorrectionLoop",
+    "Guardrail",
+]

--- a/prompt_modules/agent_persona.py
+++ b/prompt_modules/agent_persona.py
@@ -1,0 +1,6 @@
+from dataclasses import dataclass
+
+@dataclass
+class AgentPersona:
+    name: str
+    description: str

--- a/prompt_modules/correction_loop.py
+++ b/prompt_modules/correction_loop.py
@@ -1,0 +1,6 @@
+from dataclasses import dataclass
+
+@dataclass
+class CorrectionLoop:
+    max_iterations: int
+    criteria: str

--- a/prompt_modules/guardrail.py
+++ b/prompt_modules/guardrail.py
@@ -1,0 +1,6 @@
+from dataclasses import dataclass
+from typing import List
+
+@dataclass
+class Guardrail:
+    rules: List[str]

--- a/prompt_modules/prompt_template.py
+++ b/prompt_modules/prompt_template.py
@@ -1,0 +1,6 @@
+from dataclasses import dataclass
+
+@dataclass
+class PromptTemplate:
+    name: str
+    template: str

--- a/prompt_modules/workflow_map.py
+++ b/prompt_modules/workflow_map.py
@@ -1,0 +1,6 @@
+from dataclasses import dataclass
+from typing import List
+
+@dataclass
+class WorkflowMap:
+    steps: List[str]

--- a/tests/test_generate_gpt_config.py
+++ b/tests/test_generate_gpt_config.py
@@ -1,0 +1,44 @@
+import json
+import os
+import subprocess
+import sys
+test_data = {
+    "prompt_template": {"name": "Test", "template": "Hello {name}"},
+    "agent_persona": {"name": "Assistant", "description": "Helpful"},
+    "workflow_map": {"steps": ["step1", "step2"]},
+    "correction_loop": {"max_iterations": 2, "criteria": "accuracy"},
+    "guardrail": {"rules": ["rule1", "rule2"]},
+}
+
+
+def run_script(tmpdir):
+    session_path = os.path.join(tmpdir, "session.json")
+    with open(session_path, "w") as f:
+        json.dump(test_data, f)
+
+    subprocess.check_call([
+        sys.executable,
+        os.path.join(os.path.dirname(__file__), os.pardir, "generate_gpt_config.py"),
+        session_path,
+        tmpdir,
+    ])
+    return session_path
+
+
+def test_files_created(tmp_path):
+    run_script(tmp_path)
+    expected_files = [
+        "prompt_template.json",
+        "agent_persona.json",
+        "workflow_map.json",
+        "correction_loop.json",
+        "guardrail.json",
+        "custom_gpt_config.json",
+        "workspace_project.md",
+    ]
+    for fname in expected_files:
+        assert (tmp_path / fname).exists(), f"{fname} not created"
+
+    with open(tmp_path / "custom_gpt_config.json") as f:
+        data = json.load(f)
+    assert data["prompt_template"]["name"] == "Test"


### PR DESCRIPTION
## Summary
- implement `prompt_modules` package for prompt workflow classes
- add `generate_gpt_config.py` to build config/markdown from session data
- provide unit tests for the generator
- document usage in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684790be019483319511cf83053985f2

## Summary by Sourcery

Add prompt_modules dataclass package and generate_gpt_config.py script to produce JSON configs and Markdown from session data, with accompanying tests and documentation.

New Features:
- Introduce `prompt_modules` package with dataclasses for prompt workflows
- Implement `generate_gpt_config.py` to generate individual and combined JSON config files and a Markdown summary from session data

Documentation:
- Update README with instructions for using the config generator

Tests:
- Add unit test for `generate_gpt_config.py` to verify expected files and content are produced