### PR TITLE
Add license and contributing docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,25 @@
+# Contributing to ai-musicology-gpt
+
+Thank you for taking the time to contribute!
+
+## Reporting Issues
+
+Please use the GitHub [issue tracker](https://github.com/black-da-bull/ai-musicology-gpt/issues) to report bugs or suggest features. When filing an issue, include a clear description and steps to reproduce if applicable.
+
+## Submitting Pull Requests
+
+1. Fork the repository and create a new branch for your feature or fix.
+2. Make your changes with clear commit messages.
+3. Ensure all tests pass (see below).
+4. Open a pull request targeting the `main` branch and describe your changes.
+
+## Running Tests
+
+This project currently uses `pytest` for testing. After installing the dependencies, run:
+
+```bash
+pytest -q
+```
+
+If no tests are present, the command will report that no tests were found.
+

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,22 @@
+MIT License
+
+Copyright (c) 2025 The ai-musicology-gpt developers
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+

--- a/README.md
+++ b/README.md
@@ -1,1 +1,7 @@
 # ai-musicology-gpt
+
+An exploration of generative models in musicology.
+
+- [License](LICENSE)
+- [Contributing Guidelines](CONTRIBUTING.md)
+


### PR DESCRIPTION
## Summary
- add MIT `LICENSE`
- document contributing steps in `CONTRIBUTING.md`
- point to the new documents from the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684790c06e208331bb3407dec9dfbd9b

## Summary by Sourcery

Introduce an MIT license and contribution guidelines, and update the README to reference them

Documentation:
- Add MIT LICENSE file
- Add CONTRIBUTING.md with issue and PR instructions
- Link LICENSE and CONTRIBUTING.md from README